### PR TITLE
Fix code example for cube file export

### DIFF
--- a/examples/chemistry/qchem_modelling_basics.ipynb
+++ b/examples/chemistry/qchem_modelling_basics.ipynb
@@ -23,7 +23,7 @@
     "    import tangelo\n",
     "except ImportError:\n",
     "    !pip install git+https://github.com/goodchemistryco/Tangelo.git --quiet\n",
-    "    !pip install pyscf --quiet"
+    "    !pip install pyscf --quiet\n"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o2_xyz = [(\"O\", (0., 0., 0.)), (\"O\", (0., 0., 1.21))]"
+    "o2_xyz = [(\"O\", (0., 0., 0.)), (\"O\", (0., 0., 1.21))]\n"
    ]
   },
   {
@@ -142,7 +142,7 @@
     "from tangelo import SecondQuantizedMolecule\n",
     "o2_sto3g = SecondQuantizedMolecule(o2_xyz, q=0, spin=2)\n",
     "print(f\"{o2_sto3g.n_active_mos} active molecular orbitals\")\n",
-    "print(f\"{o2_sto3g.n_active_electrons} active electrons\")"
+    "print(f\"{o2_sto3g.n_active_electrons} active electrons\")\n"
    ]
   },
   {
@@ -189,7 +189,7 @@
     "    \"6-311+G(d,p)\", # Triple zeta with polarization functions and diffuse functions.\n",
     "    \"cc-pvqz\",      # Quadruple zeta.\n",
     "    \"cc-pv5z\"       # Quintuple zeta.\n",
-    "]"
+    "]\n"
    ]
   },
   {
@@ -252,12 +252,12 @@
     "\n",
     "# Perform a Mean-Field calculation for each basis set.\n",
     "for bs in basis_sets:\n",
-    "    \n",
+    "\n",
     "    # Measure execution time.\n",
     "    start = time.time()\n",
     "    scan_basis_mol = SecondQuantizedMolecule(o2_xyz, q=0, spin=2, basis=bs)\n",
     "    end = time.time()\n",
-    "    \n",
+    "\n",
     "    mf_energies.append(scan_basis_mol.mf_energy)\n",
     "    mf_times.append(end-start)\n",
     "\n",
@@ -277,7 +277,7 @@
     "\n",
     "# Show the graph.\n",
     "plt.tick_params(axis=\"both\", direction=\"in\")\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -327,10 +327,10 @@
     }
    ],
    "source": [
-    "o2_6311gdp = SecondQuantizedMolecule(o2_xyz, q=0, spin=2, \n",
+    "o2_6311gdp = SecondQuantizedMolecule(o2_xyz, q=0, spin=2,\n",
     "                                     basis=\"6-311G(d,p)\", frozen_orbitals=None)\n",
     "print(f\"{o2_6311gdp.n_active_mos} active molecular orbitals\")\n",
-    "print(f\"{o2_6311gdp.n_active_electrons} active electrons\")"
+    "print(f\"{o2_6311gdp.n_active_electrons} active electrons\")\n"
    ]
   },
   {
@@ -365,7 +365,7 @@
     }
    ],
    "source": [
-    "o2_6311gdp.mo_occ"
+    "o2_6311gdp.mo_occ\n"
    ]
   },
   {
@@ -399,10 +399,10 @@
     "# Selecting HOMO-3 to LUMO+3 orbitals.\n",
     "frozen = get_orbitals_excluding_homo_lumo(o2_6311gdp, homo_minus_n=3, lumo_plus_n=3)\n",
     "\n",
-    "o2_6311gdp_frozen = SecondQuantizedMolecule(o2_xyz, q=0, spin=2, basis=\"6-311G(d,p)\", \n",
+    "o2_6311gdp_frozen = SecondQuantizedMolecule(o2_xyz, q=0, spin=2, basis=\"6-311G(d,p)\",\n",
     "                                            frozen_orbitals=frozen)\n",
     "print(f\"{o2_6311gdp_frozen.n_active_mos} active molecular orbitals\")\n",
-    "print(f\"{o2_6311gdp_frozen.n_active_electrons} active electrons\")"
+    "print(f\"{o2_6311gdp_frozen.n_active_electrons} active electrons\")\n"
    ]
   },
   {
@@ -436,7 +436,7 @@
     "# CCSD energy with HOMO-3 to LUMO+3 orbitals.\n",
     "e_o2_6311gdp_frozen = CCSDSolver(o2_6311gdp_frozen).simulate()\n",
     "\n",
-    "print(f\"Energy difference: {abs(e_o2_6311gdp-e_o2_6311gdp_frozen)*627.5} kcal/mol.\")"
+    "print(f\"Energy difference: {abs(e_o2_6311gdp-e_o2_6311gdp_frozen)*627.5} kcal/mol.\")\n"
    ]
   },
   {
@@ -478,14 +478,14 @@
     "\n",
     "hamiltonian = fermion_to_qubit_mapping(o2_6311gdp_frozen.fermionic_hamiltonian, \"JW\")\n",
     "n_qubits = count_qubits(hamiltonian)\n",
-    "taper = QubitTapering(hamiltonian, n_qubits, \n",
+    "taper = QubitTapering(hamiltonian, n_qubits,\n",
     "                      n_electrons=o2_6311gdp_frozen.n_active_electrons)\n",
     "hamiltonian_taper = taper.z2_tapered_op\n",
     "n_qubits_tapered = count_qubits(hamiltonian_taper)\n",
     "\n",
     "print(f\"Number of qubits: {n_qubits}\")\n",
     "print(f\"Number of qubits after tapering: {n_qubits_tapered}\")\n",
-    "print(f\"{n_qubits - n_qubits_tapered} Z2 symmetries detected\")"
+    "print(f\"{n_qubits - n_qubits_tapered} Z2 symmetries detected\")\n"
    ]
   },
   {
@@ -501,7 +501,8 @@
     "A `SecondQuantizedMolecule` object can be exported as a `pyscf.gto.Mole` object. From that point, anything implemented in `PySCF` can be applied to this data structure. The next line shows how to do this operation.\n",
     "\n",
     "```python\n",
-    "pyscf_mol = sec_mol.to_pyscf(sec_mol.basis)\n",
+    "from tangelo.toolboxes.molecular_computation.integral_solver_pyscf import mol_to_pyscf\n",
+    "pyscf_mol = mol_to_pyscf(sec_mol, sec_mol.basis, sec_mol.symmetry, sec_mol.ecp)\n",
     "```\n",
     "\n",
     "### Extracting Mean-Field Quantities<a class=\"anchor\" id=\"51\"></a>\n",
@@ -586,7 +587,7 @@
     }
    ],
    "source": [
-    "o2_sto3g.mean_field.analyze(verbose=5);"
+    "o2_sto3g.mean_field.analyze(verbose=5);\n"
    ]
   },
   {


### PR DESCRIPTION
```python
pyscf_mol = sec_mol.to_pyscf(sec_mol.basis)
```
to
```python
from tangelo.toolboxes.molecular_computation.integral_solver_pyscf import mol_to_pyscf,
pyscf_mol = mol_to_pyscf(sec_mol, sec_mol.basis, sec_mol.symmetry, sec_mol.ecp)
```

This code is not executed in the notebook, that's why the tests did not fail.