### PR TITLE
ci: declare explicit workflow permissions and pin actions to commit SHAs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Python
-      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,6 +2,9 @@ name: Continuous Integration
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -11,9 +14,9 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -65,11 +68,11 @@ jobs:
       if: always()
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: notebook-test-results
         path: examples/junit/notebook-test-results.xml
 
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: write   # quarto publish pushes the rendered site to gh-pages
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -12,13 +15,13 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
 
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2
         with:
           target: gh-pages
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write   # quarto publish pushes the rendered site to gh-pages
     steps:
       - name: Check out repository
-        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,16 @@ on:
   push:
     branches: main
 
+# Workflow-level default is read-only so any job added later starts least-privileged.
+# The one job that needs to push is granted write explicitly below.
 permissions:
-  contents: write   # quarto publish pushes the rendered site to gh-pages
+  contents: read
 
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write   # quarto publish pushes the rendered site to gh-pages
     steps:
       - name: Check out repository
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3


### PR DESCRIPTION
Declares explicit `permissions:` on both workflows and pins every action to a
commit SHA.

## Changes

**Explicit `permissions:`** — neither workflow declared one, so every job
inherited the repository default. Sized per workflow by reading what each
actually does rather than applied uniformly:

| Workflow | Granted | Why |
|---|---|---|
| `continuous_integration.yml` | `contents: read` | `on: [pull_request]`, read-only |
| `publish.yml` | workflow-level `contents: read`, job-level `contents: write` | `quarto publish` pushes the rendered site to `gh-pages`; the default stays read-only so any job added later starts least-privileged |

**All `uses:` refs pinned to commit SHAs**, each with a trailing version comment
so readability and Renovate/Dependabot updates are preserved. A mutable tag can
be repointed by whoever controls the action repo; a SHA can't.

**Action majors raised.** Pinning `checkout@v2` / `setup-python@v2` at their
current commits would have frozen those majors permanently, with no upgrade path
— which is arguably worse than a floating tag that still receives patches. So
they're raised as part of the same change:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` (CI) | v2 | v4 (`11d5960a`, v4.4.0) |
| `actions/setup-python` (CI) | v2 | v5 (`a26af69b`, v5.6.0) |
| `actions/checkout` (publish) | v3 | v4 (`11d5960a`, v4.4.0) |

`python-version` is `3.9`, so the `setup-python` v5 YAML-float quoting issue
(which affects 3.10+) doesn't apply here.

## Validation

- Both files parse (`yaml.safe_load`).
- Zero unpinned `uses:` refs remain — re-grepped for anything not `@<40-hex>`.
- **All 7 pins verified to resolve to the tag their comment claims**, by querying
  each action repo's own tag list for the commit — not assumed from the tag name.
- `permissions:` blocks confirmed parsed at the correct scope.

## Note on CI status

This repo's CI is red for reasons that predate this PR — the `projectq` wheel
build fails against modern setuptools, and `test_linq_basics_notebook` needs
`pennylane`. Neither is touched here. The comparison that matters: the run
before the action-major bump and the run after it fail identically.
